### PR TITLE
Don't re-export any modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,11 @@ Once you install it, use it by importing it unqualified:
 import Batteries
 ```
 
-Batteries includes a few modules that clash with each other. To use them,
-import them qualified:
+That's it!
 
-``` purescript
-import qualified Batteries.Array as Array
-```
-
-That's it! If you know of a package that should be included, please open a pull
-request. And if Batteries doesn't export something that you need from one of
-the included packages, please open an issue.
+If you know of a package that should be included, please open a pull request.
+And if Batteries doesn't export something that you need from one of the
+included packages, please open an issue.
 
 Batteries includes the following packages:
 

--- a/src/Batteries/Array.purs
+++ b/src/Batteries/Array.purs
@@ -1,8 +1,0 @@
-module Batteries.Array
-  ( module Batteries.Array
-  , module Data.Array
-  , module Data.Array.ST
-  ) where
-
-import Data.Array
-import Data.Array.ST

--- a/src/Batteries/CatList.purs
+++ b/src/Batteries/CatList.purs
@@ -1,6 +1,0 @@
-module Batteries.CatList
-  ( module Batteries.CatList
-  , module Data.CatList
-  ) where
-
-import Data.CatList

--- a/src/Batteries/CatQueue.purs
+++ b/src/Batteries/CatQueue.purs
@@ -1,6 +1,0 @@
-module Batteries.CatQueue
-  ( module Batteries.CatQueue
-  , module Data.CatQueue
-  ) where
-
-import Data.CatQueue

--- a/src/Batteries/List.purs
+++ b/src/Batteries/List.purs
@@ -1,8 +1,0 @@
-module Batteries.List
-  ( module Batteries.List
-  , module Data.List
-  , module Data.List.ZipList
-  ) where
-
-import Data.List
-import Data.List.ZipList

--- a/src/Batteries/Map.purs
+++ b/src/Batteries/Map.purs
@@ -1,6 +1,0 @@
-module Batteries.Map
-  ( module Batteries.Map
-  , module Data.Map
-  ) where
-
-import Data.Map

--- a/src/Batteries/Set.purs
+++ b/src/Batteries/Set.purs
@@ -1,6 +1,0 @@
-module Batteries.Set
-  ( module Batteries.Set
-  , module Data.Set
-  ) where
-
-import Data.Set

--- a/src/Batteries/StrMap.purs
+++ b/src/Batteries/StrMap.purs
@@ -1,6 +1,0 @@
-module Batteries.StrMap
-  ( module Batteries.StrMap
-  , module Data.StrMap
-  ) where
-
-import Data.StrMap


### PR DESCRIPTION
This pull request fixes #9. It changes Batteries to not re-export any modules. So instead of importing `Batteries.Array`, you will have to import `Data.Array`. 
