### PR TITLE
Update purescript-generics to 0.7.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-foreign": "~0.7.2",
     "purescript-free": "~0.9.0",
     "purescript-functions": "~0.1.0",
-    "purescript-generics": "~0.6.2",
+    "purescript-generics": "~0.7.0",
     "purescript-globals": "~0.2.2",
     "purescript-identity": "~0.4.1",
     "purescript-inject": "~0.3.0",

--- a/src/Batteries.purs
+++ b/src/Batteries.purs
@@ -2218,8 +2218,6 @@ import Data.Generic
   ( Generic
   , GenericSignature(SigArray, SigBoolean, SigChar, SigInt, SigNumber, SigProd, SigRecord, SigString)
   , GenericSpine(SArray, SBoolean, SChar, SInt, SNumber, SProd, SRecord, SString)
-  , Proxy(Proxy)
-  , anyProxy
   , fromSpine
   , gCompare
   , gEq
@@ -3014,8 +3012,8 @@ import Test.Assert
   , assertThrows'
   )
 import Type.Proxy
-  ( -- Proxy(Proxy) -- NOTE: Data.Generic
-    Proxy2(Proxy2)
+  ( Proxy(Proxy)
+  , Proxy2(Proxy2)
   , Proxy3(Proxy3)
   )
 import Unsafe.Coerce


### PR DESCRIPTION
`anyProxy` is now gone, it's not even in `Type.Proxy`. Means the next release of `purescript-batteries` will require a major version bump.
