### PR TITLE
Update to purescript 0.8.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "bower": "1.7.2",
     "pulp": "7.0.0",
-    "purescript": "0.7.6"
+    "purescript": "0.8.0-rc.1"
   },
   "engines": {
     "node": "5.4.0",


### PR DESCRIPTION
This pull request should never be merged. Batteries should stay on PureScript 0.7.x until there's a non-RC 0.8.x release. However I thought it could be useful to get all the warnings generated by the new version. 
