### PR TITLE
get rid of purescript-lens

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,6 @@
     "purescript-integers": "~2.1.0",
     "purescript-invariant": "~2.0.0",
     "purescript-lazy": "~2.0.0",
-    "purescript-lens": "~2.0.0",
     "purescript-lists": "~3.4.0",
     "purescript-maps": "~2.1.1",
     "purescript-math": "~2.0.0",

--- a/src/Batteries.purs
+++ b/src/Batteries.purs
@@ -171,13 +171,6 @@ module Batteries
   , module Global
   , module Global.Unsafe
   , module Math
-  , module Optic.Core
-  , module Optic.Getter
-  , module Optic.Laws.Lens
-  , module Optic.Lens
-  , module Optic.Prism
-  , module Optic.Setter
-  , module Optic.Types
   , module Prelude
   , module Test.Assert
   , module Type.Proxy
@@ -1625,83 +1618,6 @@ import Math
   , sqrt2
   , tan
   , (%)
-  )
-import Optic.Core
-  ( (..)
-  )
-import Optic.Getter
-  ( to
-  , view
-  , weiv
-  , (^.)
-  )
-import Optic.Laws.Lens
-  ( getSet
-  , setGet
-  , setSet
-  , validLens
-  )
-import Optic.Lens
-  ( flip'
-  , lens
-  , (??)
-  )
-import Optic.Prism
-  ( clonePrism
-  , is
-  , isn't
-  , matching
-  , nearly
-  , only
-  , prism
-  , prism'
-  , withPrism
-  )
-import Optic.Setter
-  -- ( add -- NOTE: Prelude
-  -- , and -- NOTE: Prelude
-  ( argument
-  -- , concat -- NOTE: Data.List
-  , contramapped
-  -- , div -- NOTE: Prelude
-  , mapped
-  -- , mul -- NOTE: Prelude
-  -- , or -- NOTE: Prelude
-  , over
-  , set
-  , set'
-  , setJust
-  , sets
-  -- , sub -- NOTE: Prelude
-  , (-~)
-  , (?~)
-  , (.~)
-  , (*~)
-  , (/~)
-  , (&&~)
-  , (%~)
-  , (+~)
-  , (<>~)
-  , (||~)
-  )
-import Optic.Types
-  ( Accessing
-  , APrism
-  , APrism'
-  , ASetter
-  , ASetter'
-  , Getter
-  , Getting
-  , Lens
-  , Lens'
-  , Optical
-  , Optical'
-  , Prism
-  , Prism'
-  , Setter
-  , Setter'
-  , Setting
-  , Setting'
   )
 import Prelude
   ( class Applicative


### PR DESCRIPTION
Doing this as a pull request instead of an issue because I'm lazy (I don't mean to impose; feel free to disagree and close this).

`purescript-profunctor-lenses` is a very useful package with all the fixings. `Iso`s, `MonadState`-manipulators, indexed optics, nice built-ins like `_Left` and `_1`, etc.

But right now in order to use it you have to hide a bunch of conflicting imports from Batteries (or suffer the warnings).

Also, if you accidentally use a function like `view` from `Optic.Lens` instead of `Data.Lens` because you forgot to explicitly import the right version, you will have a bad time, because the types will *almost* line up, but not quite, and you'll spend an hour trying to figure out what you typed wrong because you only *kinda* understand `Profunctor`s. (The type errors -- my god, the type errors).

`purescript-lens` (unlike the rest of Batteries) does not seem like a "community standard" package. It seems like an opinionated package, and I think it's reasonable to choose `purescript-profunctor-lenses` instead for many applications (or maybe that's the standard now; I don't know).